### PR TITLE
Added gem 'hydra-head' to Gemfile

### DIFF
--- a/doc/Lesson:-add-the-Hydra-dependencies.md
+++ b/doc/Lesson:-add-the-Hydra-dependencies.md
@@ -16,9 +16,10 @@ Open up `Gemfile` in your editor.   We're going to add the following lines after
 
 ```ruby
 gem 'hydra'
+gem 'hydra-head'
 ```
 
-This includes the hydra-gem in our application.  Bundler will then ensure that the hydra-head, blacklight, active-fedora and other gems required by hydra get included (required) correctly. This includes a dependency for the jettywrapper gem (installed automatically). The jettywrapper gem is used to install and configure a preconfigured instance of jetty that loads and runs local development instances of Fedora and Solr for you to run and test your application against.
+This includes the hydra and hydra-head gems in our application.  Bundler will then ensure that the blacklight, active-fedora and other gems required by hydra get included (required) correctly. This includes a dependency for the jettywrapper gem (installed automatically). The jettywrapper gem is used to install and configure a preconfigured instance of jetty that loads and runs local development instances of Fedora and Solr for you to run and test your application against.
 
 Now save the change and install the dependencies by running bundler:
 ```text


### PR DESCRIPTION
I found that gem 'hydra-head' had to be in the Gemfile in order for hydra-jetty to start successfully. Without hydra-head in the Gemfile, I would get "Unable to move tmp/jetty_generator/hydra-jetty-master into jetty/ Operation not permitted - (tmp/jetty_generator/hydra-jetty-master, jetty)" when I tried to run the hydra-jetty generator. With hydra-head in the Gemfile, this problem was solved. I tried this after seeing the instructions for hydra-head installation at https://github.com/projecthydra/hydra-head, where gem 'hydra-head' is included in the gemfile. 
